### PR TITLE
Add cross-platform build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            runs_on: ubuntu-latest
+            vscode_arch: x64
+            archive: tar.gz
+            artifact: openvscode-server-linux-x64
+          - platform: darwin
+            runs_on: macos-latest
+            vscode_arch: arm64
+            archive: tar.gz
+            artifact: openvscode-server-darwin-arm64
+          - platform: win32
+            runs_on: windows-latest
+            vscode_arch: x64
+            archive: zip
+            artifact: openvscode-server-win32-x64
+    runs-on: ${{ matrix.runs_on }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - run: npm ci
+      - if: matrix.platform != 'win32'
+        run: |
+          npm run server:init
+          npm run gulp vscode-reh-${{ matrix.platform }}-${{ matrix.vscode_arch }}-min
+          mv ../vscode-reh-${{ matrix.platform }}-${{ matrix.vscode_arch }} ../vscode-server-${{ matrix.platform }}-${{ matrix.vscode_arch }}
+          tar -czf ${{ matrix.artifact }}.${{ matrix.archive }} -C .. vscode-server-${{ matrix.platform }}-${{ matrix.vscode_arch }}
+      - if: matrix.platform == 'win32'
+        run: |
+          npm run server:init
+          npm run gulp vscode-reh-${{ matrix.platform }}-${{ matrix.vscode_arch }}-min
+          Move-Item ..\\vscode-reh-${{ matrix.platform }}-${{ matrix.vscode_arch }} ..\\vscode-server-${{ matrix.platform }}-${{ matrix.vscode_arch }}
+          Compress-Archive -Path ..\\vscode-server-${{ matrix.platform }}-${{ matrix.vscode_arch }} -DestinationPath ${{ matrix.artifact }}.${{ matrix.archive }}
+        shell: pwsh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.${{ matrix.archive }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and archive server for Linux, macOS, and Windows

## Testing
- `npm test`
- `npm ci` *(fails: cannot find gssapi/gssapi.h)*

------
https://chatgpt.com/codex/tasks/task_e_68b123ae7358832d83815731db266bf0